### PR TITLE
Django 1.8 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ the Puppet Forge:
     $ virtualenv forge
     $ source forge/bin/activate
     $ pip install django-forge
-    $ django-admin.py syncdb --noinput --settings=forge.settings.dev
+    $ django-admin.py migrate --noinput --settings=forge.settings.dev
     $ django-admin.py sync_forge --settings=forge.settings.dev
     $ django-admin.py runserver --settings=forge.settings.dev
 

--- a/forge/settings/base.py
+++ b/forge/settings/base.py
@@ -23,6 +23,17 @@ STATIC_ROOT = ''
 
 ROOT_URLCONF = 'forge.urls'
 
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.security.SecurityMiddleware',
+)
+
 TEMPLATE_DIRS = (
     os.path.join(FORGE_HOME, 'templates'),
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(name='django-forge',
       url='https://github.com/jbronn/django-forge',
       download_url='http://pypi.python.org/pypi/django-forge/',
       install_requires=[
-        'Django>=1.4',
+        'Django>=1.8',
         'requests>=2',
         'semantic_version>=2.1.2',
       ],


### PR DESCRIPTION
This PR adds the `MIDDLEWARE_CLASSES` necessary to work with Django 1.8 (see also #10), which i this package now requires.

The `README` is also updated to use the `migrate` management command since `syncdb` is no more.
